### PR TITLE
Change suggested by moewew in issue #25.

### DIFF
--- a/trad-abbrv.bbx
+++ b/trad-abbrv.bbx
@@ -16,10 +16,14 @@
 }
 
 \DeclareNameFormat{abbrv}{%
-  \usebibmacro{name:first-last}{#1}{#4}{#6}{#8}%
+  \nameparts{#1}%
+  \usebibmacro{name:given-family}
+      {\namepartfamily}
+      {\namepartgiveni}
+      {\namepartprefixi}
+      {\namepartsuffixi}%
   \usebibmacro{name:andothers}}
 \DeclareNameAlias{default}{abbrv}
-
 
 \DeclareFieldFormat{bibentrysetcount}{\mkbibparens{\mknumalph{#1}}}
 \DeclareFieldFormat{labelnumberwidth}{\mkbibbrackets{#1}}


### PR DESCRIPTION
This implements moewew's proposed fix to make trad-abbrv compatible with biblatex 3.3. I tested it using the existing testcases in testfolder, and it appears to work fine.